### PR TITLE
Update ABBA.py

### DIFF
--- a/ABBA.py
+++ b/ABBA.py
@@ -364,7 +364,11 @@ class ABBA(object):
 
         # Construct deep copy and scale data
         data = deepcopy(pieces[:,0:2])
-
+        num_k = np.unique(np.array(data), axis=1).shape[0]
+        if num_k >= self.min_k:
+            self.min_k = num_k - 1
+            if num_k >= self.max_k:
+                self.max_k = num_k - 1
         ########################################################################
         #     'incremental'
         ########################################################################


### PR DESCRIPTION
This pull request solve the problem when the number of unique pieces is greater than the number of clusters to be specified, Without this, it raises the warning: 

 _**ConvergenceWarning: Number of distinct clusters (6) found smaller than n_clusters (9). Possibly due to duplicate points in X.
  kmeans = KMeans(n_clusters=k, tol=0, random_state=0).fit(data)
ConvergenceWarning: Number of distinct clusters (8) found smaller than n_clusters (9). Possibly due to duplicate points in X.
  kmeans = KMeans(n_clusters=k, tol=0, random_state=0).fit(data)**_